### PR TITLE
Correcting the name of the imported packaged and the GIT repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ npm install rxaviers/async-pool
 ```
 
 ```js
-import asyncPool from "async-pool";
+import asyncPool from "tiny-async-pool";
 ```
 
 ### ES7 async

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:rxaviers/assertion.git"
+    "url": "git@github.com:rxaviers/async-pool.git"
   },
   "keywords": [
     "race",


### PR DESCRIPTION
Great job!

Using your library I discovered that the module name is "tiny-async-pool" (in the package.json), while in the README.md file you use `import asyncPool from "async-pool"`. At the same time, I thing the GIT repo in the package.json file is addressing another repo.

Minor changes, but I wanted to thank you :-)