### PR TITLE
Improve assertion consistency

### DIFF
--- a/lib/es6.js
+++ b/lib/es6.js
@@ -1,10 +1,12 @@
-let assert, assertType;
-if (process.env.NODE_ENV === "development") {
+let shouldAssert = process.env.NODE_ENV === "development",
+    assert, assertType;
+
+if (shouldAssert) {
   ({ assert, assertType } = require("yaassertion"));
 }
 
 function asyncPool(poolLimit, array, iteratorFn) {
-  if (process.env.NODE_ENV === "development") {
+  if (shouldAssert) {
     try {
       assertType(poolLimit, "poolLimit", ["number"]);
       assertType(array, "array", ["array"]);

--- a/lib/es7.js
+++ b/lib/es7.js
@@ -1,10 +1,12 @@
-let assert, assertType;
-if (process.env.NODE_ENV === "development") {
+let shouldAssert = process.env.NODE_ENV === "development",
+    assert, assertType;
+
+if (shouldAssert) {
   ({ assert, assertType } = require("yaassertion"));
 }
 
 async function asyncPool(poolLimit, array, iteratorFn) {
-  if (process.env.NODE_ENV === "development") {
+  if (shouldAssert) {
     assertType(poolLimit, "poolLimit", ["number"]);
     assertType(array, "array", ["array"]);
     assertType(iteratorFn, "iteratorFn", ["function"]);


### PR DESCRIPTION
Fixes the following error if `process.env.NODE_ENV` is changed at run-time:

```
TypeError: assertType is not a function
    at asyncPool (/tiny-async-pool/lib/es7.js:8:5)
```

In my case the library that changed the var was [node-env-file](https://github.com/grimen/node-env-file/blob/master/lib/index.js#L120).