### PR TITLE
feat: merge return to resolve

### DIFF
--- a/lib/es6.js
+++ b/lib/es6.js
@@ -7,7 +7,7 @@ function asyncPool(poolLimit, iterable, iteratorFn) {
       return Promise.resolve();
     }
     const item = iterable[i++];
-    const p = Promise.resolve().then(() => iteratorFn(item, iterable));
+    const p = Promise.resolve(iteratorFn(item, iterable));
     ret.push(p);
     executing.add(p);
     const clean = () => executing.delete(p);

--- a/lib/es7.js
+++ b/lib/es7.js
@@ -2,7 +2,7 @@ async function asyncPool(poolLimit, iterable, iteratorFn) {
   const ret = [];
   const executing = new Set();
   for (const item of iterable) {
-    const p = Promise.resolve().then(() => iteratorFn(item, iterable));
+    const p = Promise.resolve(iteratorFn(item, iterable));
     ret.push(p);
     executing.add(p);
     const clean = () => executing.delete(p);


### PR DESCRIPTION
I think `const p = Promise.resolve().then(() => iteratorFn(item, iterable));` === `  const p = Promise.resolve(iteratorFn(item, iterable));`, 

So i simplify  and test it. I am not sure if this branch is still being maintained, but I have still submitted this merge request for your review. Could you please review it? Thank you.